### PR TITLE
don't wrap frontend command in 'sh -c'

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web-backend: python -m uvicorn app.main:app --uds /var/run/cabotage/cabotage.sock
-web-frontend: sh -c 'node server.js & socat UNIX-LISTEN:/var/run/cabotage/cabotage.sock,fork TCP:127.0.0.1:3000'
+web-frontend: node server.js & socat UNIX-LISTEN:/var/run/cabotage/cabotage.sock,fork TCP:127.0.0.1:3000
 release: echo 'doin deploy things'


### PR DESCRIPTION
envconsul complains with:

```
starting child: fork/exec sh -c 'node server.js & socat UNIX-LISTEN:/var/run/cabotage/cabotage.sock: no such file or directory
```