### PR TITLE
add a dummy ci to auto deploy to cabotage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: Dummy-CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Pass
+      run: echo Success!


### PR DESCRIPTION
cabotage will not auto deploy unless a status check goes green after push.